### PR TITLE
Relax the sphinx version to give a bit more flexiblity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ PyYAML==5.1
 requests==2.21.0
 six==1.12.0
 snowballstemmer==1.2.1
-Sphinx==1.8.3
+Sphinx>=1.8.3
 sphinx-markdown-builder==0.4.0
 sphinxcontrib-websupport==1.1.0
 typing==3.6.6


### PR DESCRIPTION
For example, I cannot use it with 1.8.5